### PR TITLE
feat: add initial items support to InMemoryRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.0
+
+- Added support for initial items in InMemoryRepository constructor
+- Repository can now be initialized with pre-populated data
+
 ## 0.12.0
 
 - fixed silent error when not found on deletion

--- a/lib/src/in_memory_repository.dart
+++ b/lib/src/in_memory_repository.dart
@@ -36,11 +36,15 @@ String _generateId() {
 /// final repository = InMemoryRepository<MyObject>(
 ///   queryBuilder: MyQueryBuilder(),
 ///   path: 'my_objects',
+///   initialItems: [
+///     IdentifiedObject('id1', MyObject(name: 'Initial Item 1')),
+///     IdentifiedObject('id2', MyObject(name: 'Initial Item 2')),
+///   ],
 /// );
 ///
 /// // Add an item
 /// final item = MyObject(name: 'test');
-/// final added = await repository.add(IdentifiedObject('id1', item));
+/// final added = await repository.add(IdentifiedObject('id3', item));
 ///
 /// // Get an item
 /// final retrieved = await repository.get('id1');
@@ -50,11 +54,27 @@ String _generateId() {
 /// ```
 class InMemoryRepository<T> implements Repository<T> {
   /// Creates a new in-memory repository.
+  ///
+  /// [queryBuilder] - Builder for creating custom filter queries
+  /// [path] - The path/namespace for this repository
+  /// [initialItems] - Optional collection of items to populate the
+  /// repository with on creation
   InMemoryRepository({
     required QueryBuilder<InMemoryFilterQuery<T>> queryBuilder,
     required String path,
+    Iterable<IdentifiedObject<T>>? initialItems,
   })  : _queryBuilder = queryBuilder,
-        _path = path;
+        _path = path {
+    if (initialItems != null) {
+      for (final item in initialItems) {
+        final itemPath = _fullItemPath(item.id);
+        _items[itemPath] = item.object;
+      }
+      if (initialItems.isNotEmpty) {
+        _queryStreamController.add(List<T>.unmodifiable(_items.values));
+      }
+    }
+  }
   final QueryBuilder<InMemoryFilterQuery<T>> _queryBuilder;
   final String _path;
   final Map<String, T> _items = {};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kiss_repository
 description: A simple generic repository interface
-version: 0.12.0
+version: 0.13.0
 repository: https://github.com/WAMF/kiss_repository
 
 environment:


### PR DESCRIPTION
- Add optional initialItems parameter to constructor
- Populate repository with initial data on creation
- Update query stream when initial items provided
- Bump version to 0.13.0
- Update CHANGELOG and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initializing repositories with pre-populated items during creation.

* **Documentation**
  * Updated changelog and example usage to reflect the new initialization feature.

* **Chores**
  * Bumped package version to 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->