### PR TITLE
fix: create parent directory in JsonFileRepository._saveToFile

### DIFF
--- a/lib/src/json_file_repository.dart
+++ b/lib/src/json_file_repository.dart
@@ -116,6 +116,7 @@ class JsonFileRepository<T> implements Repository<T> {
       _items.forEach((key, value) {
         json[key] = _toJson(value);
       });
+      await _file.parent.create(recursive: true);
       await _file.writeAsString(jsonEncode(json));
     } catch (e) {
       throw RepositoryException(

--- a/test/json_file_repository_test.dart
+++ b/test/json_file_repository_test.dart
@@ -119,6 +119,31 @@ void main() {
       repo.dispose();
     });
 
+    test('creates parent directories if they do not exist', () async {
+      final nestedFile = File(
+        '${tempDir.path}/nested/dirs/that/dont/exist/data.json',
+      );
+      expect(nestedFile.parent.existsSync(), isFalse);
+
+      final repo = JsonFileRepository<TestObject>(
+        queryBuilder: TestQueryBuilder(),
+        path: 'test_objects',
+        file: nestedFile,
+        fromJson: TestObject.fromJson,
+        toJson: (obj) => obj.toJson(),
+      );
+
+      await repo.add(
+        IdentifiedObject(
+          'nested-1',
+          const TestObject(name: 'Nested', value: 7),
+        ),
+      );
+
+      expect(nestedFile.existsSync(), isTrue);
+      repo.dispose();
+    });
+
     test('persists and loads 50 items correctly', () async {
       final repo1 = JsonFileRepository<TestObject>(
         queryBuilder: TestQueryBuilder(),


### PR DESCRIPTION
## Summary
- Ensure `_saveToFile` creates the target file's parent directory tree before writing, so `add` succeeds against fresh paths whose parent directories don't yet exist.
- Add a test covering the new-directory case.

Fixes #22

## Test plan
- [ ] `dart test test/json_file_repository_test.dart` passes (could not run locally — no dart toolchain in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpz6VKSH9ZFn3FkCYneaeL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File persistence now automatically creates all required nested parent directories before saving data, enabling successful writes to new file paths without manual directory setup.

* **Tests**
  * Added test coverage for deeply nested file paths to verify parent directories are created correctly during file save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->