### PR TITLE
fix(example): pin pocketbase to a bounded version range (#26)

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   kiss_pocketbase_repository: ^0.1.0
   kiss_repository: ^0.11.0
   meta: ^1.11.0
-  pocketbase: any
+  pocketbase: ^0.22.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,4 @@ dependencies:
 dev_dependencies:
   test: ^1.25.0
   very_good_analysis: ^6.0.0
+  yaml: ^3.1.2

--- a/test/pubspec_constraints_test.dart
+++ b/test/pubspec_constraints_test.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+final _separator = Platform.pathSeparator;
+
+/// Returns [path] expressed relative to the directory [from].
+String _relativePath(String path, String from) {
+  if (!path.startsWith(from)) return path;
+  var rest = path.substring(from.length);
+  while (rest.startsWith(_separator)) {
+    rest = rest.substring(1);
+  }
+  return rest;
+}
+
+/// Returns every checked-in `pubspec.yaml` under [root].
+///
+/// Generated and cached directories are skipped, so only the pubspec files
+/// of this package and its example app are returned.
+List<String> _findPubspecs(Directory root) {
+  const skipped = {'.git', '.dart_tool', 'build', '.symlinks', 'Pods'};
+  final found = <String>[];
+  for (final entity in root.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) continue;
+    if (entity.uri.pathSegments.last != 'pubspec.yaml') continue;
+    final relative = _relativePath(entity.path, root.path);
+    if (relative.split(_separator).any(skipped.contains)) continue;
+    found.add(relative);
+  }
+  return found;
+}
+
+/// Whether a hosted version constraint declares an upper bound.
+///
+/// A caret constraint (`^1.2.3`) always implies an upper bound. Any other
+/// constraint needs an explicit `<` to be bounded. `any` and an empty
+/// constraint are therefore unbounded.
+bool _isBounded(String constraint) {
+  final value = constraint.trim();
+  if (value.isEmpty || value == 'any') return false;
+  if (value.startsWith('^')) return true;
+  return value.contains('<');
+}
+
+/// Describes each hosted dependency in [pubspecPath] with no upper bound.
+///
+/// Entries described by a map (`sdk:`, `path:`, `git:`) are not hosted
+/// version constraints, so they are skipped.
+List<String> _unboundedIn(String pubspecPath) {
+  final document = loadYaml(File(pubspecPath).readAsStringSync());
+  if (document is! YamlMap) return const [];
+
+  final offenders = <String>[];
+  for (final section in ['dependencies', 'dev_dependencies']) {
+    final entries = document[section];
+    if (entries is! YamlMap) continue;
+    entries.forEach((name, constraint) {
+      if (constraint is YamlMap) return;
+      final text = constraint?.toString() ?? '';
+      if (_isBounded(text)) return;
+      offenders.add('$pubspecPath -> $name: $text');
+    });
+  }
+  return offenders;
+}
+
+void main() {
+  group('pubspec dependency constraints', () {
+    final root = Directory.current;
+
+    test('both checked-in pubspec files are discovered', () {
+      final paths = _findPubspecs(root);
+
+      expect(paths, contains('pubspec.yaml'));
+      expect(
+        paths,
+        contains('example${_separator}pubspec.yaml'),
+        reason: 'The example app pubspec must be covered by this guard.',
+      );
+    });
+
+    test('no hosted dependency uses an unbounded version constraint', () {
+      final offenders = [
+        for (final pubspec in _findPubspecs(root)) ..._unboundedIn(pubspec),
+      ];
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'An unbounded constraint lets a build resolve a future '
+            'major release with breaking changes. Pin each dependency to a '
+            'caret range that matches the tested version. Offenders: '
+            '${offenders.join(', ')}',
+      );
+    });
+
+    test('example pins pocketbase to the version the sibling expects', () {
+      final pubspec = File('example${_separator}pubspec.yaml');
+      final document = loadYaml(pubspec.readAsStringSync()) as YamlMap;
+      final dependencies = document['dependencies'] as YamlMap;
+
+      expect(dependencies['pocketbase'], '^0.22.0');
+    });
+
+    test('bounded and unbounded constraints are told apart', () {
+      expect(_isBounded('^0.22.0'), isTrue);
+      expect(_isBounded('>=1.0.0 <2.0.0'), isTrue);
+      expect(_isBounded('  ^1.2.3  '), isTrue);
+
+      expect(_isBounded('any'), isFalse);
+      expect(_isBounded(''), isFalse);
+      expect(_isBounded('>=1.0.0'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #26.

`example/pubspec.yaml` declared `pocketbase: any`. That constraint sets no upper bound, so a build can resolve any future major release with breaking changes. This is example code, so the direct blast radius is small. Users copy example wiring into their own apps, so the pattern is worth correcting.

## The change

**1. Pin the constraint — `example/pubspec.yaml`, 1 line.**

```diff
-  pocketbase: any
+  pocketbase: ^0.22.0
```

`^0.22.0` is the version the issue asked for: the one the sibling package expects. I confirmed both facts rather than assuming them.

| Source | Value |
|---|---|
| `kiss_pocketbase_repository` 0.1.0 pubspec on pub.dev | `pocketbase: ^0.22.0` |
| `example/pubspec.lock` before this change | `pocketbase 0.22.0` |
| `example/pubspec.lock` after this change | `pocketbase 0.22.0` |

**Resolution does not change.** The example already built against 0.22.0. This pin records the tested version instead of leaving it to chance.

**2. Add a regression guard — `test/pubspec_constraints_test.dart`, new file.**

The guard scans every checked-in `pubspec.yaml` and fails on any hosted dependency with no upper bound.

- A caret constraint (`^1.2.3`) implies an upper bound. Any other constraint needs an explicit `<`.
- `any` and an empty constraint are unbounded.
- Entries described by a map (`sdk:`, `path:`, `git:`) are skipped, because they are not hosted version constraints. This is what keeps `flutter: sdk: flutter` from being reported.
- Generated directories (`.dart_tool`, `build`, `.git`, `.symlinks`, `Pods`) are skipped.

**3. Add the `yaml` dev dependency — `pubspec.yaml`, 1 line.**

The guard parses YAML properly rather than matching lines by hand. `yaml: ^3.1.2` is a dev dependency only, so it does not reach consumers of this package.

## Scope

The production change is **2 lines**. The rest is the test coverage the guard needs.

No schema, migration, auth, secret, CI, or release file is touched. The published API of `kiss_repository` is unchanged.

I deliberately reverted `example/pubspec.lock`. Running `flutter pub get` locally on Flutter 3.44.3 rewrote 19 unrelated transitive entries (`characters`, `leak_tracker`, `matcher`, and others). Those bumps have nothing to do with this issue, so they are not in this pull request. The committed lock stays valid, because the locked `0.22.0` satisfies `^0.22.0`.

## Verification

Verified at exact head `dd7b1d279f2651af3431d3f4899d71779fbba068`.

| Check | Baseline on `main` (`be49e38a`) | This head |
|---|---|---|
| `dart test` | 54 passed | **58 passed** |
| `dart analyze --fatal-infos` | 14 issues | **14 issues** |
| `dart analyze --fatal-infos test/pubspec_constraints_test.dart` | n/a | **No issues found!** |
| `flutter pub get` in `example/` | resolves | resolves, `pocketbase 0.22.0` |

**On the 14 analyze issues.** They are pre-existing and they are all in `test/shared_repository_tests.dart` (12 `lines_longer_than_80_chars`, 2 `avoid_equals_and_hash_code_on_mutable_classes`). The count is identical before and after, and my new file is clean on its own. I did not fix them, because that is unrelated to this issue. This repository has no CI workflow, so this local gate is the only lint signal before merge.

### The new tests are not vacuous

I proved this rather than asserting it. I temporarily restored `pocketbase: any` and re-ran the file:

```
+1 -1: no hosted dependency uses an unbounded version constraint [E]
       Expected: empty
         Actual: [example/pubspec.yaml -> pocketbase: any]
+1 -2: example pins pocketbase to the version the sibling expects [E]
       Expected: '^0.22.0'
         Actual: 'any'
2 tests failed, 2 passed
```

Exactly the 2 tests that cover the fix failed, and no others. With the pin restored, all 4 pass. I reverted that experiment; it is not in any commit.

## Reviewers

`kumar-waaf` and `data-wamf` are requested.
