### PR TITLE
fix(example): bind PocketBase filter values instead of interpolating (#25)

### DIFF
--- a/example/lib/repositories/providers/pocketbase_repository_provider.dart
+++ b/example/lib/repositories/providers/pocketbase_repository_provider.dart
@@ -40,7 +40,7 @@ class PocketBaseRepositoryProvider implements RepositoryProvider<ProductModel> {
           'price': product.price,
           'description': product.description,
         },
-        queryBuilder: PocketBaseProductQueryBuilder(),
+        queryBuilder: PocketBaseProductQueryBuilder(_client),
       );
 
       logger.log('✅ PocketBase repository initialized for $serverUrl');

--- a/example/lib/repositories/query_builders/pocketbase_product_query_builder.dart
+++ b/example/lib/repositories/query_builders/pocketbase_product_query_builder.dart
@@ -1,29 +1,60 @@
 import 'package:example/queries/product_queries.dart';
 import 'package:kiss_repository/kiss_repository.dart';
+// ignore: depend_on_referenced_packages
+import 'package:pocketbase/pocketbase.dart';
 
+/// Builds PocketBase filter strings for the example's [Query] types.
+///
+/// Values are bound through [PocketBase.filter] placeholders (`{:name}`)
+/// instead of being interpolated into the filter string. `filter` escapes a
+/// single quote inside a value, so a value cannot close the quoted literal and
+/// append filter syntax of its own.
+///
+/// Copy this pattern, not string interpolation, when you write a query builder
+/// for a collection of your own. A search term usually comes from a user.
 class PocketBaseProductQueryBuilder implements QueryBuilder<String> {
+  PocketBaseProductQueryBuilder(this._client);
+
+  final PocketBase _client;
+
   @override
   String build(Query query) {
     if (query is QueryByName) {
-      return "name ~ '${query.searchTerm}'";
+      return _client.filter(
+        'name ~ {:searchTerm}',
+        <String, dynamic>{'searchTerm': query.searchTerm},
+      );
     }
 
     if (query is QueryByPriceGreaterThan) {
-      return 'price > ${query.threshold}';
+      return _client.filter(
+        'price > {:threshold}',
+        <String, dynamic>{'threshold': query.threshold},
+      );
     }
 
     if (query is QueryByPriceLessThan) {
-      return 'price < ${query.threshold}';
+      return _client.filter(
+        'price < {:threshold}',
+        <String, dynamic>{'threshold': query.threshold},
+      );
     }
 
+    // The date is passed as a pre-formatted string so the emitted format stays
+    // the same as before this builder was parameterized. Passing a `DateTime`
+    // would make `filter` emit a space instead of the `T` separator.
     if (query is QueryByCreatedAfter) {
-      final dateString = query.dateTime.toIso8601String();
-      return "created > '$dateString'";
+      return _client.filter(
+        'created > {:date}',
+        <String, dynamic>{'date': query.dateTime.toIso8601String()},
+      );
     }
 
     if (query is QueryByCreatedBefore) {
-      final dateString = query.dateTime.toIso8601String();
-      return "created < '$dateString'";
+      return _client.filter(
+        'created < {:date}',
+        <String, dynamic>{'date': query.dateTime.toIso8601String()},
+      );
     }
 
     // Default: return all products

--- a/example/test/repositories/query_builders/pocketbase_product_query_builder_test.dart
+++ b/example/test/repositories/query_builders/pocketbase_product_query_builder_test.dart
@@ -1,0 +1,113 @@
+import 'package:example/queries/product_queries.dart';
+import 'package:example/repositories/query_builders/pocketbase_product_query_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiss_repository/kiss_repository.dart';
+// ignore: depend_on_referenced_packages
+import 'package:pocketbase/pocketbase.dart';
+
+void main() {
+  // `filter` only formats a string. It makes no request, so no server is
+  // needed and this URL is never contacted.
+  final client = PocketBase('http://localhost:8090');
+  final builder = PocketBaseProductQueryBuilder(client);
+
+  group('PocketBaseProductQueryBuilder', () {
+    test('quotes a plain search term', () {
+      expect(builder.build(const QueryByName('laptop')), "name ~ 'laptop'");
+    });
+
+    test('escapes a single quote in a search term', () {
+      // A legitimate value, not an attack. It must survive unchanged in
+      // meaning, and it must stay inside one quoted literal.
+      expect(
+        builder.build(const QueryByName("O'Brien")),
+        r"name ~ 'O\'Brien'",
+      );
+    });
+
+    test('a crafted search term cannot add a filter clause (#25)', () {
+      // Before this builder bound its values, the term below closed the quoted
+      // literal and appended `|| name != ''`, which matches every record and
+      // defeats the intended filter. The escaped quote keeps it one literal.
+      const payload = "x' || name != '";
+      final filter = builder.build(const QueryByName(payload));
+
+      expect(filter, r"name ~ 'x\' || name != \''");
+
+      // The interpolated builder produced exactly this, which is the breakout.
+      expect(filter, isNot("name ~ 'x' || name != ''"));
+
+      // No `||` survives outside a quoted literal.
+      expect(_unquotedPart(filter), isNot(contains('||')));
+    });
+
+    test('a crafted search term cannot comment out the rest of the filter', () {
+      const payload = "x' && 1=1 || '";
+      final filter = builder.build(const QueryByName(payload));
+
+      expect(filter, r"name ~ 'x\' && 1=1 || \''");
+      expect(_unquotedPart(filter), isNot(contains('&&')));
+    });
+
+    test('leaves a numeric threshold unquoted', () {
+      expect(
+        builder.build(const QueryByPriceGreaterThan(9.99)),
+        'price > 9.99',
+      );
+      expect(builder.build(const QueryByPriceLessThan(20.5)), 'price < 20.5');
+    });
+
+    test('keeps the ISO 8601 date format used before parameterization', () {
+      final when = DateTime.utc(2026, 8, 8, 12, 30, 45);
+      final iso = when.toIso8601String();
+
+      expect(
+        builder.build(QueryByCreatedAfter(when)),
+        "created > '$iso'",
+      );
+      expect(
+        builder.build(QueryByCreatedBefore(when)),
+        "created < '$iso'",
+      );
+      // The `T` separator must not become a space.
+      expect(iso, contains('T'));
+    });
+
+    test('returns an empty filter for an unrecognised query', () {
+      expect(builder.build(const _UnknownQuery()), isEmpty);
+    });
+  });
+}
+
+/// Returns [filter] with every single-quoted literal removed, so a test can
+/// assert that no filter syntax leaked outside a literal.
+///
+/// An escaped quote (`\'`) does not end a literal.
+String _unquotedPart(String filter) {
+  final outside = StringBuffer();
+  var inLiteral = false;
+
+  for (var i = 0; i < filter.length; i++) {
+    final char = filter[i];
+
+    if (char == r'\' && i + 1 < filter.length) {
+      i++; // Skip the escaped character.
+      continue;
+    }
+
+    if (char == "'") {
+      inLiteral = !inLiteral;
+      continue;
+    }
+
+    if (!inLiteral) {
+      outside.write(char);
+    }
+  }
+
+  return outside.toString();
+}
+
+class _UnknownQuery extends Query {
+  const _UnknownQuery();
+}


### PR DESCRIPTION
## What this changes

The example's reference query builder interpolated values straight into a PocketBase filter string. It now binds them through `PocketBase.filter` placeholders.

Closes #25.

## The defect

`example/lib/repositories/query_builders/pocketbase_product_query_builder.dart:8` built the name filter like this:

```dart
return "name ~ '${query.searchTerm}'";
```

A search term that holds a single quote closes the quoted literal and appends filter syntax of its own. With the term `x' || name != '` the builder produced:

```
name ~ 'x' || name != ''
```

That is no longer one comparison. The `||` matches every record and defeats the intended filter. I confirmed this exact output from the old code, it is not a prediction. See "The tests are not vacuous" below.

## The fix

Values are bound through `filter` placeholders, which escape a single quote inside the value:

```dart
return _client.filter(
  'name ~ {:searchTerm}',
  <String, dynamic>{'searchTerm': query.searchTerm},
);
```

The same term now produces one literal, and the injected operator is inert:

```
name ~ 'x\' || name != \''
```

`filter` needs a `PocketBase` instance. `PocketBaseRepositoryProvider` already creates one at `pocketbase_repository_provider.dart:23`, before it builds the query builder at line 43, so the client is simply passed in. No new wiring, no new dependency.

## The emitted filter does not change for legitimate input

This matters, because a security fix should not quietly change query results.

- **Numbers** stay unquoted: `price > 9.99`, exactly as before.
- **Dates** are passed as pre-formatted strings, so the ISO 8601 `T` separator is kept: `created > '2026-08-08T12:30:45.000Z'`. Passing a `DateTime` to `filter` would have emitted a space instead of the `T`, which would have changed date queries. A test pins the `T`.
- **Plain search terms** are unchanged: `name ~ 'laptop'`.

Only a value containing a single quote changes, which is the point.

## Why the documentation matters here

This is example code, so it is not on a live path in this repository. The report's own risk note is that the example is presented as the canonical pattern for consumers, so the unsafe version was likely to be copied into production code. The class documentation now states that the binding is the part to copy.

## Testing

`example/` had no test directory. This PR adds one, with 7 tests in `example/test/repositories/query_builders/pocketbase_product_query_builder_test.dart`:

- A plain term is quoted.
- A legitimate apostrophe (`O'Brien`) is escaped and keeps its meaning.
- **Two crafted terms cannot add a clause.** Each is asserted twice: once against the exact expected output, and once by stripping every quoted literal and confirming that no `||` or `&&` survives outside one. The second assertion does not depend on the exact escaping style.
- Numeric thresholds stay unquoted.
- The ISO 8601 date format is preserved.
- An unrecognised query still returns an empty filter.

### Verified at exact head `dbcaf0106ba50bed2d2098226fed53270b45f153`

- `flutter test` in `example/` — **7 passed**, 0 failed.
- `flutter analyze` in `example/` — **No issues found**, same as the baseline before my change.
- `dart test` at the repository root — **54 passed**, unchanged. This PR does not touch the package.
- `dart analyze --fatal-infos` at the root — 14 issues, the **same 14 pre-existing** issues in `test/shared_repository_tests.dart` as on `main`. None are mine.

### The tests are not vacuous

I temporarily restored the old interpolation and re-ran. **Exactly the 3 string tests failed, and no others.** The failure output showed the real breakout:

```
Expected: name ~ 'x\' || name != \''
  Actual: name ~ 'x' || name != ''
```

The numeric, date, and default tests kept passing, which confirms they are independent of this change. I then reverted the experiment and confirmed the committed file matches the fix before pushing.

## Scope

Two example files changed plus one new test file. No schema, auth, secrets, CI, or public API change. The package's own `lib/` is untouched.

I deliberately left `example/pubspec.lock` out. Running `flutter pub get` rewrote 38 lines of unrelated transitive entries, which is scope creep. It is also already the subject of #27.

## Related, and deliberately not in this PR

The report notes the same anti-pattern in `WAMF/kiss_pocketbase_repository` at `test/integration/factories/pocketbase_query_builder.dart`. That is a different repository, so it needs its own issue and PR. I have not changed it here.
