### PR TITLE
refactor(example): clear both high-complexity findings in ProductListWidget (#24)

### DIFF
--- a/example/lib/utils/product_edit.dart
+++ b/example/lib/utils/product_edit.dart
@@ -1,0 +1,38 @@
+import 'package:example/models/product_model.dart';
+
+/// The outcome of validating the product edit dialog input.
+///
+/// Exactly one field is set. `price` holds the parsed price when the input is
+/// valid. `error` holds the message to show the user when it is not.
+typedef ProductEditValidation = ({double? price, String? error});
+
+/// Validates the name and price that the product edit dialog collected.
+///
+/// The price is parsed once, so the caller does not parse it again.
+ProductEditValidation validateProductEdit({
+  required String name,
+  required String priceText,
+}) {
+  if (name.isEmpty || priceText.isEmpty) {
+    return (price: null, error: 'Name and price are required');
+  }
+
+  final price = double.tryParse(priceText);
+  if (price == null || price < 0) {
+    return (price: null, error: 'Please enter a valid price');
+  }
+
+  return (price: price, error: null);
+}
+
+/// True when the edited values change at least one field of [product].
+bool productEditChangesProduct(
+  ProductModel product, {
+  required String name,
+  required double price,
+  required String description,
+}) {
+  return name != product.name ||
+      price != product.price ||
+      description != product.description;
+}

--- a/example/lib/utils/relative_time.dart
+++ b/example/lib/utils/relative_time.dart
@@ -1,0 +1,49 @@
+const _monthAbbreviations = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/// Formats [created] the way the product list shows a creation time.
+///
+/// A time less than a week old reads as a relative label, such as `Just now`
+/// or `5 minutes ago`. Anything older reads as a full local date and time.
+///
+/// [now] defaults to [DateTime.now]. Tests pass a fixed value.
+String formatCreatedDate(DateTime created, {DateTime? now}) {
+  final localCreated = created.toLocal();
+  final difference = (now ?? DateTime.now()).difference(localCreated);
+  return _relativeLabel(difference) ?? _absoluteLabel(localCreated);
+}
+
+/// The relative label for [difference], or `null` when it is a week or more.
+String? _relativeLabel(Duration difference) {
+  if (difference.inMinutes < 1) return 'Just now';
+  if (difference.inHours < 1) return _agoLabel(difference.inMinutes, 'minute');
+  if (difference.inDays < 1) return _agoLabel(difference.inHours, 'hour');
+  if (difference.inDays < 7) return _agoLabel(difference.inDays, 'day');
+  return null;
+}
+
+String _agoLabel(int count, String unit) =>
+    '$count $unit${count == 1 ? '' : 's'} ago';
+
+String _absoluteLabel(DateTime localCreated) {
+  final month = _monthAbbreviations[localCreated.month - 1];
+  final minute = localCreated.minute.toString().padLeft(2, '0');
+  final hour = localCreated.hour;
+  final amPm = hour >= 12 ? 'PM' : 'AM';
+  final displayHour = hour == 0 ? 12 : (hour > 12 ? hour - 12 : hour);
+
+  return '$month ${localCreated.day}, ${localCreated.year} '
+      'at $displayHour:$minute $amPm';
+}

--- a/example/lib/widgets/product_list_widget.dart
+++ b/example/lib/widgets/product_list_widget.dart
@@ -1,4 +1,6 @@
 import 'package:example/models/product_model.dart';
+import 'package:example/utils/product_edit.dart';
+import 'package:example/utils/relative_time.dart';
 import 'package:flutter/material.dart';
 import 'package:kiss_repository/kiss_repository.dart';
 
@@ -78,44 +80,45 @@ class ProductListWidget extends StatelessWidget {
       ),
     );
 
-    if (result != null) {
-      final newName = result['name']!;
-      final priceText = result['price']!;
-      final newDescription = result['description']!;
+    if (result == null) return;
 
-      if (newName.isEmpty || priceText.isEmpty) {
-        // ignore: use_build_context_synchronously
-        _showSnackBar(context, 'Name and price are required');
-        return;
+    final newName = result['name']!;
+    final newDescription = result['description']!;
+
+    final validation = validateProductEdit(
+      name: newName,
+      priceText: result['price']!,
+    );
+    if (validation.error != null) {
+      // ignore: use_build_context_synchronously
+      _showSnackBar(context, validation.error!);
+      return;
+    }
+    final newPrice = validation.price!;
+
+    final changesProduct = productEditChangesProduct(
+      product,
+      name: newName,
+      price: newPrice,
+      description: newDescription,
+    );
+    if (!changesProduct) return;
+
+    try {
+      await productRepository.update(
+        product.id,
+        (current) => current.copyWith(
+          name: newName,
+          price: newPrice,
+          description: newDescription,
+        ),
+      );
+      if (context.mounted) {
+        _showSnackBar(context, 'Product updated successfully!');
       }
-
-      final newPrice = double.tryParse(priceText);
-      if (newPrice == null || newPrice < 0) {
-        // ignore: use_build_context_synchronously
-        _showSnackBar(context, 'Please enter a valid price');
-        return;
-      }
-
-      if (newName != product.name ||
-          newPrice != product.price ||
-          newDescription != product.description) {
-        try {
-          await productRepository.update(
-            product.id,
-            (current) => current.copyWith(
-              name: newName,
-              price: newPrice,
-              description: newDescription,
-            ),
-          );
-          if (context.mounted) {
-            _showSnackBar(context, 'Product updated successfully!');
-          }
-        } catch (e) {
-          if (context.mounted) {
-            _showSnackBar(context, 'Error updating product: $e');
-          }
-        }
+    } catch (e) {
+      if (context.mounted) {
+        _showSnackBar(context, 'Error updating product: $e');
       }
     }
   }
@@ -123,58 +126,6 @@ class ProductListWidget extends StatelessWidget {
   void _showSnackBar(BuildContext context, String message) {
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text(message)));
-  }
-
-  String _formatCreatedDate(DateTime created) {
-    final now = DateTime.now();
-    final localCreated = created.toLocal();
-    final difference = now.difference(localCreated);
-
-    // If it's within the last minute
-    if (difference.inMinutes < 1) {
-      return 'Just now';
-    }
-    // If it's within the last hour
-    else if (difference.inHours < 1) {
-      final minutes = difference.inMinutes;
-      return '$minutes minute${minutes == 1 ? '' : 's'} ago';
-    }
-    // If it's within the last 24 hours
-    else if (difference.inDays < 1) {
-      final hours = difference.inHours;
-      return '$hours hour${hours == 1 ? '' : 's'} ago';
-    }
-    // If it's within the last week
-    else if (difference.inDays < 7) {
-      final days = difference.inDays;
-      return '$days day${days == 1 ? '' : 's'} ago';
-    }
-    // For older dates, show the full date
-    else {
-      final months = [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec',
-      ];
-      final month = months[localCreated.month - 1];
-      final day = localCreated.day;
-      final year = localCreated.year;
-      final hour = localCreated.hour;
-      final minute = localCreated.minute.toString().padLeft(2, '0');
-      final amPm = hour >= 12 ? 'PM' : 'AM';
-      final displayHour = hour == 0 ? 12 : (hour > 12 ? hour - 12 : hour);
-
-      return '$month $day, $year at $displayHour:$minute $amPm';
-    }
   }
 
   @override
@@ -228,7 +179,7 @@ class ProductListWidget extends StatelessWidget {
           itemCount: products.length,
           itemBuilder: (context, index) {
             final product = products[index];
-            final createString = _formatCreatedDate(product.created);
+            final createString = formatCreatedDate(product.created);
             return Card(
               child: ListTile(
                 leading: CircleAvatar(

--- a/example/test/utils/product_edit_test.dart
+++ b/example/test/utils/product_edit_test.dart
@@ -1,0 +1,119 @@
+import 'package:example/models/product_model.dart';
+import 'package:example/utils/product_edit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final product = ProductModel(
+    id: 'p1',
+    name: 'Widget',
+    price: 9.5,
+    description: 'A widget',
+    created: DateTime(2026, 8, 9),
+  );
+
+  group('validateProductEdit', () {
+    test('accepts a valid name and price and returns the parsed price', () {
+      final result = validateProductEdit(name: 'Widget', priceText: '12.75');
+      expect(result.error, isNull);
+      expect(result.price, 12.75);
+    });
+
+    test('accepts a price of zero', () {
+      final result = validateProductEdit(name: 'Widget', priceText: '0');
+      expect(result.error, isNull);
+      expect(result.price, 0);
+    });
+
+    test('rejects an empty name', () {
+      final result = validateProductEdit(name: '', priceText: '12.75');
+      expect(result.error, 'Name and price are required');
+      expect(result.price, isNull);
+    });
+
+    test('rejects an empty price', () {
+      final result = validateProductEdit(name: 'Widget', priceText: '');
+      expect(result.error, 'Name and price are required');
+      expect(result.price, isNull);
+    });
+
+    test('reports the missing-field error before the invalid-price error', () {
+      // Both fields are wrong. The first message must win, as it did before.
+      final result = validateProductEdit(name: '', priceText: 'abc');
+      expect(result.error, 'Name and price are required');
+    });
+
+    test('rejects a price that is not a number', () {
+      final result = validateProductEdit(name: 'Widget', priceText: 'abc');
+      expect(result.error, 'Please enter a valid price');
+      expect(result.price, isNull);
+    });
+
+    test('rejects a negative price', () {
+      final result = validateProductEdit(name: 'Widget', priceText: '-1');
+      expect(result.error, 'Please enter a valid price');
+      expect(result.price, isNull);
+    });
+  });
+
+  group('productEditChangesProduct', () {
+    test('is false when nothing changed', () {
+      expect(
+        productEditChangesProduct(
+          product,
+          name: 'Widget',
+          price: 9.5,
+          description: 'A widget',
+        ),
+        isFalse,
+      );
+    });
+
+    test('is true when only the name changed', () {
+      expect(
+        productEditChangesProduct(
+          product,
+          name: 'Gadget',
+          price: 9.5,
+          description: 'A widget',
+        ),
+        isTrue,
+      );
+    });
+
+    test('is true when only the price changed', () {
+      expect(
+        productEditChangesProduct(
+          product,
+          name: 'Widget',
+          price: 9.75,
+          description: 'A widget',
+        ),
+        isTrue,
+      );
+    });
+
+    test('is true when only the description changed', () {
+      expect(
+        productEditChangesProduct(
+          product,
+          name: 'Widget',
+          price: 9.5,
+          description: 'Another widget',
+        ),
+        isTrue,
+      );
+    });
+
+    test('is true when the description is cleared', () {
+      expect(
+        productEditChangesProduct(
+          product,
+          name: 'Widget',
+          price: 9.5,
+          description: '',
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/example/test/utils/relative_time_test.dart
+++ b/example/test/utils/relative_time_test.dart
@@ -1,0 +1,116 @@
+import 'package:example/utils/relative_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // A fixed local reference time keeps every expectation deterministic.
+  final now = DateTime(2026, 8, 9, 13, 45, 30);
+
+  String format(Duration ago) => formatCreatedDate(now.subtract(ago), now: now);
+
+  group('formatCreatedDate relative labels', () {
+    test('under a minute reads "Just now"', () {
+      expect(format(Duration.zero), 'Just now');
+      expect(format(const Duration(seconds: 59)), 'Just now');
+    });
+
+    test('a time in the future also reads "Just now"', () {
+      expect(format(const Duration(seconds: -30)), 'Just now');
+      expect(format(const Duration(days: -400)), 'Just now');
+    });
+
+    test('minutes are singular at one and plural above one', () {
+      expect(format(const Duration(minutes: 1)), '1 minute ago');
+      expect(format(const Duration(minutes: 2)), '2 minutes ago');
+      expect(format(const Duration(minutes: 59)), '59 minutes ago');
+    });
+
+    test('hours are singular at one and plural above one', () {
+      expect(format(const Duration(hours: 1)), '1 hour ago');
+      expect(format(const Duration(hours: 2)), '2 hours ago');
+      expect(format(const Duration(hours: 23)), '23 hours ago');
+    });
+
+    test('days are singular at one and plural above one', () {
+      expect(format(const Duration(days: 1)), '1 day ago');
+      expect(format(const Duration(days: 2)), '2 days ago');
+      expect(format(const Duration(days: 6)), '6 days ago');
+    });
+
+    test('the unit changes on the exact boundary, not before it', () {
+      expect(format(const Duration(seconds: 59)), 'Just now');
+      expect(format(const Duration(seconds: 60)), '1 minute ago');
+
+      expect(
+        format(const Duration(minutes: 59, seconds: 59)),
+        '59 minutes ago',
+      );
+      expect(format(const Duration(minutes: 60)), '1 hour ago');
+
+      expect(format(const Duration(hours: 23, minutes: 59)), '23 hours ago');
+      expect(format(const Duration(hours: 24)), '1 day ago');
+    });
+
+    test('a whole week stops being relative and becomes a full date', () {
+      expect(format(const Duration(days: 6, hours: 23)), '6 days ago');
+      expect(format(const Duration(days: 7)), 'Aug 2, 2026 at 1:45 PM');
+    });
+  });
+
+  group('formatCreatedDate absolute labels', () {
+    String at(DateTime created) => formatCreatedDate(created, now: now);
+
+    test('midnight shows 12 AM, not 0 AM', () {
+      expect(at(DateTime(2020, 3, 4)), 'Mar 4, 2020 at 12:00 AM');
+    });
+
+    test('noon shows 12 PM', () {
+      expect(at(DateTime(2020, 3, 4, 12)), 'Mar 4, 2020 at 12:00 PM');
+    });
+
+    test('the hour before noon is AM and the hour after is PM', () {
+      expect(at(DateTime(2020, 3, 4, 11, 59)), 'Mar 4, 2020 at 11:59 AM');
+      expect(at(DateTime(2020, 3, 4, 13)), 'Mar 4, 2020 at 1:00 PM');
+      expect(at(DateTime(2020, 3, 4, 23, 30)), 'Mar 4, 2020 at 11:30 PM');
+    });
+
+    test('a single-digit minute keeps its leading zero', () {
+      expect(at(DateTime(2020, 3, 4, 9, 5)), 'Mar 4, 2020 at 9:05 AM');
+    });
+
+    test('every month maps to the right abbreviation', () {
+      const expected = [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ];
+      for (var month = 1; month <= 12; month++) {
+        expect(
+          at(DateTime(2020, month, 15, 10)),
+          '${expected[month - 1]} 15, 2020 at 10:00 AM',
+          reason: 'month $month',
+        );
+      }
+    });
+
+    test('a leap day formats as itself', () {
+      expect(at(DateTime(2024, 2, 29, 6, 7)), 'Feb 29, 2024 at 6:07 AM');
+    });
+  });
+
+  test('a UTC time is converted to local before it is formatted', () {
+    final local = DateTime(2020, 5, 6, 8, 9);
+    expect(
+      formatCreatedDate(local.toUtc(), now: now),
+      formatCreatedDate(local, now: now),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

One tranche of #24. It clears **both** `high-complexity` findings that `dallow` reports for this repository. It changes no published library code — every change is inside `example/`.

`dallow analyze . --format json --fail-on never` goes from **59 findings to 57**, and **nothing is added**.

I claimed the tranche on the issue first: https://github.com/WAMF/kiss_repository/issues/24#issuecomment-5232982180

## The two findings

```
warning high-complexity example/lib/widgets/product_list_widget.dart:27
  Function 'ProductListWidget._updateProduct' has cyclomatic complexity 12; maximum is 10.
warning high-complexity example/lib/widgets/product_list_widget.dart:128
  Function 'ProductListWidget._formatCreatedDate' has cyclomatic complexity 11; maximum is 10.
```

Both functions mixed a pure decision with widget work. That is why they scored high, and it is also why neither could be tested. This PR moves the pure part out of each one.

- **`example/lib/utils/relative_time.dart`** — `formatCreatedDate(DateTime created, {DateTime? now})`. The body is split into a relative label, an absolute label, and one pluralisation helper. `now` defaults to `DateTime.now()`, so the caller is unchanged; a test passes a fixed value.
- **`example/lib/utils/product_edit.dart`** — `validateProductEdit` returns the parsed price or the message to show, and `productEditChangesProduct` answers whether the edit changes anything.

`_updateProduct` keeps the dialog and the repository call. It now reads as four early returns instead of three nested `if` blocks.

## Behaviour is unchanged, and I proved it rather than asserting it

I wrote a temporary oracle test that held the **pre-refactor body of `_formatCreatedDate` verbatim**, with `now` injected, and compared it against the new helper over **112,269 inputs**: a 7-second sweep from 2 minutes in the future out to 9 days in the past, every hour of every month, all ten branch boundaries, a leap day, and year boundaries. Every comparison agreed.

I then confirmed the oracle was not vacuous. I broke the new code six ways, and the oracle caught all six:

| Mutation | Caught |
| --- | --- |
| `difference.inHours < 1` → `<= 1` | yes |
| `difference.inDays < 7` → `< 8` | yes |
| `hour >= 12 ? 'PM'` → `hour > 12 ? 'PM'` | yes |
| `count == 1 ? '' : 's'` → `count == 0 ? '' : 's'` | yes |
| month index `month - 1` → `month % 12` | yes |
| drop the `hour == 0 ? 12` midnight case | yes |

**The oracle is deliberately not committed.** A verbatim copy of an 11-complexity function inside a test file would re-add the very `high-complexity` finding this PR removes, and would add `duplicate-code` findings too. The committed tests are table-driven with literal expected strings instead, which pins the same behaviour without that cost. The findings diff below confirms this worked.

## One change that is not behaviour-neutral, and is intentional

The price was parsed twice before: once by `double.tryParse` for validation, then the parsed value was reused. `validateProductEdit` now parses once and returns the value. The observable result is identical, and the tests pin the two rejection messages and their order.

## What I did NOT take

- **The 55 `duplicate-code` findings.** Most are the `InMemoryRepository` / `JsonFileRepository` pair reporting the same shared behaviour twice. Collapsing that pair changes the internals of a published package and needs its own design discussion.
- **The `dead-code` finding on `_idCounter` — because it is a FALSE POSITIVE.** `dallow` says `Unused variable '_idCounter' is never referenced from any entrypoint` at `lib/src/in_memory_repository.dart:16`. It **is** referenced, at line 19, by `_generateId()`, which `InMemoryRepository.autoIdentify` calls at line 173. `autoIdentify` is a public override and is already covered by `test/shared_repository_tests.dart:411`. I proved the finding is wrong by deleting the variable and running the suite:

  ```
  lib/src/in_memory_repository.dart:17:17: Error: Getter not found: '_idCounter'.
      return 'Mem-${_idCounter++}';
                    ^^^^^^^^^^
  ```

  Acting on that finding by deletion would break the build. I have recorded this on the issue so no later run tries it.

## Verification

Run from a clean clone at commit `255ce8ca09111a4b7c15439922245016881355be`.

| Check | Result |
| --- | --- |
| `dallow analyze . --format json --fail-on never` | **59 → 57**; the 2 removed are exactly the 2 `high-complexity` findings; 0 added |
| `flutter analyze` (`example/`) | `No issues found!` |
| `flutter test` (`example/`) | **26 passed** (new; the example had no tests before) |
| `dart analyze --fatal-infos` (root) | 14 issues — **identical count on `main`**, all pre-existing, none in files I touched |
| `dart test` (root) | **54 passed** |
| `dart format` | clean on every file I touched |

I compared the full `dallow` message list before and after. The only line that differs beyond the two removed findings is the health-score line, because it embeds the function count (298 → 337, from the new helpers and tests):

```
=== ONLY in after (new findings) ===
Project health score: 99/100 (337 function(s) analysed; complexity penalty 0; findings penalty 1).
=== ONLY in before (removed) ===
Function 'ProductListWidget._formatCreatedDate' has cyclomatic complexity 11; maximum is 10.
Function 'ProductListWidget._updateProduct' has cyclomatic complexity 12; maximum is 10.
```

I also re-ran the baseline **after** `flutter pub get` resolved the example's dependencies, because `dallow`'s reading can change once a per-package `.dart_tool` exists. The count was 59 both ways, so the baseline is stable and the 59 → 57 comparison is valid.

## Notes for the reviewer

- **This repository has no CI.** There are no workflows in `.github/`, so nothing runs these tests automatically and no formatter SDK is pinned. Every result above is from a local run, which I have stated for each check. Adding CI is out of scope here.
- Line counts: the production change is 87 added lines across two new files, and `product_list_widget.dart` **shrinks** by 40 lines net. The remaining 235 lines are the two new test files.
- Pre-existing and untouched: the three `TextEditingController` instances in `_updateProduct` are never disposed. I did not change it, because it is not what this tranche is about and it is not one of the findings.

## Test plan

- [x] `flutter analyze` clean in `example/`
- [x] `flutter test` — 26 pass in `example/`
- [x] `dart analyze --fatal-infos` and `dart test` — root unchanged, 54 pass
- [x] `dallow` 59 → 57, nothing added
- [x] Equivalence oracle over 112,269 inputs, plus 6 mutations all caught

## UI-testing disposition

The example app's product list renders the same string for every input; I proved that over 112,269 comparisons against the original code. Both changed functions are pure and now unit-tested. Running the example app needs a live Firebase or PocketBase backend, which is not available here, so a browser pass would add no evidence that the equivalence proof does not already give.

Refs #24
